### PR TITLE
Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 - [ ] No cracks/chips in sunroof
 - [ ] No signs of rust or locking-up on the brakes
   - Clear visually
-- [ ] Sharfin antenna is seated properly
+- [ ] Sharkfin antenna is seated properly
   - Check for a good seal
   - No signs of separation
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 ## Before you drive
 
 - [ ] Verify the car's included equipment with the window sticker
-- [ ] Make sure you receive (2) keys
-  - [ ] (1) Black
+- [ ] Make sure you receive (3) keys
+  - [ ] (2) Black
   - [ ] (1) Orange
 
 ### Exterior

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 ## Before you drive
 
 - [ ] Verify the car's included equipment with the window sticker
-- [ ] Make sure you receive (3) keys
-  - [ ] (2) Black
+- [ ] Make sure you receive at least two keys
+  - [ ] (1 or 2) Black
   - [ ] (1) Orange
 
 ### Exterior


### PR DESCRIPTION
Minor update to reflect that 2021 XC40 Recharge models had two black keys and one orange - I assume this carries through on the 2022 and C40 models.

Also fixes minor typo when referring to the sharkfin antenna.